### PR TITLE
Fixes #9 by making it compatible with Java 7 while compiling with 8

### DIFF
--- a/scoop-basics/build.gradle
+++ b/scoop-basics/build.gradle
@@ -4,6 +4,11 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 
     packagingOptions {
         exclude 'META-INF/services/javax.annotation.processing.Processor'

--- a/scoop/build.gradle
+++ b/scoop/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'java'
 apply plugin: 'idea'
 
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
+
 configurations {
     provided
 }


### PR DESCRIPTION
```
➜  scoop git:(the-ocho) java -version
java version "1.8.0_40"
Java(TM) SE Runtime Environment (build 1.8.0_40-b27)
Java HotSpot(TM) 64-Bit Server VM (build 25.40-b25, mixed mode)
```

```
➜  scoop git:(the-ocho) ./gradlew clean installDebug
Parallel execution is an incubating feature.
:scoop-basics:clean
:scoop:clean
:scoop:compileJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
:scoop:processResources UP-TO-DATE
:scoop:classes
:scoop:jar
:scoop-basics:preBuild UP-TO-DATE
:scoop-basics:preDebugBuild UP-TO-DATE
:scoop-basics:checkDebugManifest
:scoop-basics:preReleaseBuild UP-TO-DATE
:scoop-basics:prepareComAndroidSupportAppcompatV72221Library
:scoop-basics:prepareComAndroidSupportDesign2221Library
:scoop-basics:prepareComAndroidSupportMultidex100Library
:scoop-basics:prepareComAndroidSupportSupportV42221Library
:scoop-basics:prepareComGoogleAndroidGmsPlayServicesBase810Library
:scoop-basics:prepareComGoogleAndroidGmsPlayServicesBasement810Library
:scoop-basics:prepareComGoogleAndroidGmsPlayServicesLocation810Library
:scoop-basics:prepareComGoogleAndroidGmsPlayServicesMaps810Library
:scoop-basics:prepareIoReactivexRxandroid101Library
:scoop-basics:prepareDebugDependencies
:scoop-basics:compileDebugAidl
:scoop-basics:compileDebugRenderscript
:scoop-basics:generateDebugBuildConfig
:scoop-basics:generateDebugAssets UP-TO-DATE
:scoop-basics:mergeDebugAssets
:scoop-basics:generateDebugResValues UP-TO-DATE
:scoop-basics:generateDebugResources
:scoop-basics:mergeDebugResources
:scoop-basics:processDebugManifest
:scoop-basics:processDebugResources
:scoop-basics:generateDebugSources
:scoop-basics:processDebugJavaRes UP-TO-DATE
:scoop-basics:compileDebugJavaWithJavac
Note: /Users/eveliotarazona/Development/scoop/scoop-basics/src/main/java/com/example/scoop/basics/common/Objects.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
:scoop-basics:compileDebugNdk UP-TO-DATE
:scoop-basics:compileDebugSources
:scoop-basics:preDexDebug
:scoop-basics:dexDebug
:scoop-basics:validateDebugSigning
:scoop-basics:packageDebug
:scoop-basics:zipalignDebug
:scoop-basics:assembleDebug
:scoop-basics:installDebug
Installing APK 'scoop-basics-debug.apk' on 'Nexus 6P - 6.0.1'
Installed on 1 device.

BUILD SUCCESSFUL

Total time: 13.63 secs
```