### PR TITLE
Avoid destroying scoops when popped from the backstack and clean up

### DIFF
--- a/scoop-basics/src/main/java/com/example/scoop/basics/scoop/AppRouter.java
+++ b/scoop-basics/src/main/java/com/example/scoop/basics/scoop/AppRouter.java
@@ -1,7 +1,7 @@
 package com.example.scoop.basics.scoop;
 
-import com.lyft.scoop.Router;
 import com.lyft.scoop.RouteChange;
+import com.lyft.scoop.Router;
 import com.lyft.scoop.ScreenScooper;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;

--- a/scoop/src/main/java/com/lyft/scoop/RouteChange.java
+++ b/scoop/src/main/java/com/lyft/scoop/RouteChange.java
@@ -11,7 +11,6 @@ public class RouteChange {
         this.scoop = scoop;
         this.previous = previous;
         this.next = next;
-
         this.direction = direction;
     }
 }

--- a/scoop/src/main/java/com/lyft/scoop/Router.java
+++ b/scoop/src/main/java/com/lyft/scoop/Router.java
@@ -140,6 +140,10 @@ public abstract class Router {
         return !backStack.isEmpty();
     }
 
+    public void clear() {
+        backStack.clear();
+    }
+
     private boolean tryHandleEmptyBackstack(final Screen screen) {
         if (backStack.isEmpty()) {
             final Scoop newScoop = screenScooper.createScreenScoop(screen, root);

--- a/scoop/src/main/java/com/lyft/scoop/Router.java
+++ b/scoop/src/main/java/com/lyft/scoop/Router.java
@@ -154,7 +154,7 @@ public abstract class Router {
         onScoopChanged(new RouteChange(scoop, previous, next, direction));
     }
 
-    private boolean sameScreen(Screen previous, Screen next) {
+    static boolean sameScreen(Screen previous, Screen next) {
         return previous != null && previous.equals(next);
     }
 }

--- a/scoop/src/main/java/com/lyft/scoop/ScoopBackstack.java
+++ b/scoop/src/main/java/com/lyft/scoop/ScoopBackstack.java
@@ -1,31 +1,7 @@
 package com.lyft.scoop;
 
 import java.util.ArrayDeque;
+import java.util.Deque;
 
-class ScoopBackstack {
-
-    ArrayDeque<Scoop> backStack = new ArrayDeque<>();
-
-    public void pop() {
-        Scoop poppedScoop = backStack.pop();
-        poppedScoop.destroy();
-    }
-
-    public boolean isEmpty() {
-        return backStack.isEmpty();
-    }
-
-    public Scoop peek() {
-        return backStack.peek();
-    }
-
-    public void push(Scoop scoop) {
-        backStack.push(scoop);
-    }
-
-    public void clear() {
-        while(!backStack.isEmpty()) {
-            pop();
-        }
-    }
+class ScoopBackstack extends ArrayDeque<Scoop> implements Deque<Scoop> {
 }

--- a/scoop/src/main/java/com/lyft/scoop/UiContainer.java
+++ b/scoop/src/main/java/com/lyft/scoop/UiContainer.java
@@ -26,10 +26,6 @@ public abstract class UiContainer extends FrameLayout implements HandleBack, Tra
 
     public UiContainer(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-
-        if (isInEditMode()) {
-            return;
-        }
     }
 
     protected ViewControllerInflater getViewControllerInflater() {
@@ -61,7 +57,8 @@ public abstract class UiContainer extends FrameLayout implements HandleBack, Tra
         isTransitioning = false;
 
         if (!routeChangeQueue.isEmpty()) {
-            routeChangeQueue.pop();
+            final RouteChange routeChange = routeChangeQueue.pop();
+            routeChange.scoop.destroy();
 
             if (!routeChangeQueue.isEmpty()) {
                 swap(routeChangeQueue.peek());
@@ -71,56 +68,32 @@ public abstract class UiContainer extends FrameLayout implements HandleBack, Tra
 
     @Override
     public boolean dispatchTouchEvent(MotionEvent event) {
-        if (isTransitioning) {
-            return true;
-        } else {
-            return super.dispatchTouchEvent(event);
-        }
+        return isTransitioning || super.dispatchTouchEvent(event);
     }
 
     @Override
-    public boolean dispatchDragEvent(DragEvent event){
-        if (isTransitioning) {
-            return true;
-        } else {
-            return super.dispatchDragEvent(event);
-        }
+    public boolean dispatchDragEvent(DragEvent event) {
+        return isTransitioning || super.dispatchDragEvent(event);
     }
 
     @Override
-    public boolean dispatchKeyEvent(KeyEvent event){
-        if (isTransitioning) {
-            return true;
-        } else {
-            return super.dispatchKeyEvent(event);
-        }
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        return isTransitioning || super.dispatchKeyEvent(event);
     }
 
     @Override
-    public boolean dispatchKeyEventPreIme(KeyEvent event){
-        if (isTransitioning) {
-            return true;
-        } else {
-            return super.dispatchKeyEventPreIme(event);
-        }
+    public boolean dispatchKeyEventPreIme(KeyEvent event) {
+        return isTransitioning || super.dispatchKeyEventPreIme(event);
     }
 
     @Override
-    public boolean dispatchKeyShortcutEvent(KeyEvent event){
-        if (isTransitioning) {
-            return true;
-        } else {
-            return super.dispatchKeyShortcutEvent(event);
-        }
+    public boolean dispatchKeyShortcutEvent(KeyEvent event) {
+        return isTransitioning || super.dispatchKeyShortcutEvent(event);
     }
 
     @Override
-    public boolean dispatchTrackballEvent(MotionEvent event){
-        if (isTransitioning) {
-            return true;
-        } else {
-            return super.dispatchTrackballEvent(event);
-        }
+    public boolean dispatchTrackballEvent(MotionEvent event) {
+        return isTransitioning || super.dispatchTrackballEvent(event);
     }
 
     private void swap(RouteChange routeChange) {

--- a/scoop/src/test/java/com/lyft/scoop/ScoopBackstackTest.java
+++ b/scoop/src/test/java/com/lyft/scoop/ScoopBackstackTest.java
@@ -26,6 +26,6 @@ public class ScoopBackstackTest {
         Scoop scoop = new Scoop.Builder("foo").build();
         backStack.push(scoop);
         backStack.pop();
-        Assert.assertTrue(scoop.isDestroyed());
+        Assert.assertFalse(scoop.isDestroyed());
     }
 }


### PR DESCRIPTION
Problem is when we have a `UIContainer` which is out of sync with the `Router`, we can potentially be inflating/creating Views and attempting to inject them when their `Scoop` has already been destroyed:

```
router.goTo(new ScreenA());
router.goTo(new ScreenB());
router.goTo(new ScreenC());
router.resetTo(new ScreenD());
```
If each screen's transition takes time, say 1000ms, by the time the `UIContainer` tries to transition from `ScreenB` to `ScreenC`, `ScreenC` will no longer have a valid `Scoop`.

The proposed solution is that we do not destroy `Scoop` objects when they are popped from the `Backstack`.

Additionally, I've changed the `Backstack` class to be an extension of `Deque<Scoop>` and organized the `Router` class to be more logical.

Relates to issue: https://github.com/lyft/scoop/issues/47

cc: @itspbj 