### PR TITLE
Fix leaking child scopes through parent children collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 
 android:
   components:
-    - build-tools-22.0.1
+    - build-tools-23.0.1
     - android-22
     - extra-android-m2repository
     - extra-google-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 ext {
     minSdkVersion = 15
     compileSdkVersion = 22
-    buildToolsVersion = '22.0.1'
+    buildToolsVersion = '23.0.1'
     sourceCompatibility = JavaVersion.VERSION_1_7
     ci = 'true'.equals(System.getenv('CI'))
 }

--- a/scoop-basics/build.gradle
+++ b/scoop-basics/build.gradle
@@ -5,7 +5,7 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
-    
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
@@ -14,13 +14,13 @@ android {
     dexOptions {
         preDexLibraries = !rootProject.ext.ci
     }
-    
+
     packagingOptions {
         exclude 'META-INF/services/javax.annotation.processing.Processor'
     }
 
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         multiDexEnabled true

--- a/scoop/src/main/java/com/lyft/scoop/Scoop.java
+++ b/scoop/src/main/java/com/lyft/scoop/Scoop.java
@@ -35,9 +35,10 @@ public final class Scoop {
         }
 
         this.destroyed = true;
-        this.parent = null;
-        this.children.clear();
-        this.services.clear();
+
+        if (parent != null) {
+            parent.children.remove(this.getName());
+        }
     }
 
     boolean isDestroyed() {

--- a/scoop/src/test/java/com/lyft/scoop/ScoopTest.java
+++ b/scoop/src/test/java/com/lyft/scoop/ScoopTest.java
@@ -65,18 +65,32 @@ public class ScoopTest {
         FooService service2 = new FooService();
 
         Scoop childScoop = new Scoop.Builder("child", rootScoop)
-                .service("foo_service_2", service1)
+                .service("foo_service_2", service2)
                 .build();
 
-        rootScoop.destroy();
+        FooService service3 = new FooService();
 
-        Assert.assertTrue(rootScoop.isDestroyed());
+        Scoop grandChildScoop = new Scoop.Builder("grand_child", childScoop)
+                .service("foo_service_3", service3)
+                .build();
+
+        childScoop.destroy();
+
+        Assert.assertFalse(rootScoop.isDestroyed());
         Assert.assertNull(rootScoop.findChild("child"));
-        Assert.assertNull(rootScoop.findService("foo_service_1"));
+        Assert.assertNotNull(rootScoop.findService("foo_service_1"));
 
         Assert.assertTrue(childScoop.isDestroyed());
-        Assert.assertNull(childScoop.getParent());
-        Assert.assertNull(rootScoop.findService("foo_service_2"));
+        Assert.assertNotNull(childScoop.getParent());
+        Assert.assertNull(childScoop.findChild("grand_child"));
+        Assert.assertNotNull(childScoop.findService("foo_service_1"));
+        Assert.assertNotNull(childScoop.findService("foo_service_2"));
+
+        Assert.assertTrue(grandChildScoop.isDestroyed());
+        Assert.assertNotNull(grandChildScoop.getParent());
+        Assert.assertNotNull(grandChildScoop.findService("foo_service_1"));
+        Assert.assertNotNull(grandChildScoop.findService("foo_service_2"));
+        Assert.assertNotNull(grandChildScoop.findService("foo_service_3"));
     }
 
     static class FooService {


### PR DESCRIPTION
1. Child get removed, but was not removed from parent children hashmap
2. We don't need to remove reference from child to parent. (It won't create leak)
3. We don't need to clean services.  (It won't create leak)